### PR TITLE
Update items_controller.rb

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,10 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!
   
   def index
   end
   
   def new
+    authenticate_user!
     @item = Item.new
   end
 


### PR DESCRIPTION
修正前：アカウントを登録していない人も強制的にログインを求められ、新規登録画面へ遷移できない
修正後：未ログインのユーザが新規商品登録のページに移る時に限って強制的にログインを求められる。新規登録のページへうつれるようにする