### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,11 +38,8 @@ class ItemsController < ApplicationController
 
   def destroy
     @item = Item.find(params[:id])
-    if @item.destroy
-      redirect_to action: :index
-    else
-      render :show
-    end
+    @item.destroy
+    redirect_to action: :index
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,6 +36,15 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    @item = Item.find(params[:id])
+    if @item.destroy
+      redirect_to action: :index
+    else
+      render :show
+    end
+  end
+
   private
   
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update, :destroy]
-  before_action :authenticate_user!, only: [:new, :edit]
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
+  before_action :redirect_to_index, only: [:edit, :destroy]
   
   def index
     @items = Item.all.order(created_at: "DESC")
@@ -23,9 +24,6 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    unless current_user.id == @item.user.id
-      redirect_to action: :index
-    end
   end
 
   def update
@@ -37,12 +35,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.user.id == current_user.id
-      if  @item.destroy
-        redirect_to action: :index
-      else 
-        render :show
-      end
+    if  @item.destroy
+      redirect_to action: :index
+    else 
+      render :show
     end
   end
 
@@ -54,6 +50,12 @@ class ItemsController < ApplicationController
 
   def set_item 
     @item = Item.find(params[:id])
+  end
+
+  def redirect_to_index
+    unless current_user.id == @item.user.id
+      redirect_to action: :index
+    end
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!, only: [:new, :edit]
   
   def index
@@ -37,9 +37,13 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item = Item.find(params[:id])
-    @item.destroy
-    redirect_to action: :index
+    if @item.user.id == current_user.id
+      if  @item.destroy
+        redirect_to action: :index
+      else 
+        render :show
+      end
+    end
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
       <% if current_user.id == @item.user.id %>
         <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
-        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+        <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
       <% else %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 root to: "items#index"
-resources :items, only:[:index, :new, :create, :show, :edit, :update]
+resources :items, only:[:index, :new, :create, :show, :edit, :update, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 root to: "items#index"
-resources :items, only:[:index, :new, :create, :show, :edit, :update, :destroy]
+resources :items
 end


### PR DESCRIPTION
# What
商品削除機能の実装
# Why
ユーザーが商品の出品の取り消しができるようにするため
# 補足
実装条件の「 出品者だけが商品情報を削除できること」は詳細ページで、出品者でなければ削除ボタンが表示されないようになっているので、出品者だけが商品情報を削除できると考えた。
# Gyazo
[商品情報の削除](https://gyazo.com/74d09f5ddb99ed9985bd4571eb5b8641)